### PR TITLE
fix: make pills overlap

### DIFF
--- a/src/components/experiment/iteration/AddIteration.jsx
+++ b/src/components/experiment/iteration/AddIteration.jsx
@@ -39,7 +39,10 @@ export default function AddIteration({ id, handleAddIteration, name, setName }) 
               }}
               placeholder="Adding iteration..."
               value={name}
-              onChange={(e)=> setName(e.target.value)}
+              onChange={(e)=> {
+                if(e.target.value.length<=35)
+                  setName(e.target.value)
+              }}
               autoFocus
             />
       </Box>

--- a/src/components/experiment/iteration/Iteration.jsx
+++ b/src/components/experiment/iteration/Iteration.jsx
@@ -58,7 +58,10 @@ export default function Iteration({ id, iteration, edit, remove, isLocked, isLas
               }}
               placeholder="Editing iteration..."
               value={name}
-              onChange={(e)=> setName(e.target.value)}
+              onChange={(e)=> {
+                if(e.target.value.length<=35)
+                  setName(e.target.value)
+              }}
               autoFocus
             />
           )}

--- a/src/components/experiment/iteration/Iteration.jsx
+++ b/src/components/experiment/iteration/Iteration.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import { Box, Button, InputBase, Typography } from '@mui/material'
 
@@ -9,6 +9,11 @@ export default function Iteration({ id, iteration, edit, remove, isLocked, isLas
     if (!isLocked)
       setShowEdit(true)
   }
+
+  useEffect(() => {
+    if(isLocked)
+      setShowEdit(false)
+  }, [isLocked])
   return (
     <Box
       sx={{

--- a/src/components/experiment/iteration/Iteration.jsx
+++ b/src/components/experiment/iteration/Iteration.jsx
@@ -7,7 +7,7 @@ export default function Iteration({ id, iteration, edit, remove, isLocked, isLas
   const [showEdit, setShowEdit] = useState(false)
   const toggleShowEdit = () => {
     if (!isLocked)
-      setShowEdit(prev => !prev)
+      setShowEdit(true)
   }
   return (
     <Box
@@ -86,53 +86,36 @@ export default function Iteration({ id, iteration, edit, remove, isLocked, isLas
         <>
           <Box
             sx={{
-              marginLeft: '3.9rem',
-              marginTop: '.25rem',
               display: 'flex',
-              flexDirection: 'column',
+              flexDirection: 'row',
               gap: 1,
-              justifyItems: 'flex-start'
-              // overflowWrap: 'anywhere'
+              marginLeft: '4rem',
+              flexWrap: 'wrap' 
             }}
           >
-            <Box
+            <Typography
+              fontSize={12}
               sx={{
-                display: 'flex',
-                flexDirection: 'row',
-                gap: 1
-              }}
-            >
-              <Typography
-                fontSize={12}
-                sx={{
-                  padding: '.5rem',
-                  border: name.length < 10 ? '1px solid #04A53C' : '1px solid #FFF',
-                  borderRadius: 2,
-                  color:  (name.length < 10) ? '#04A53C' : '#FFF',
+                padding: '.5rem',
+                border: name.length < 10 ? '1px solid #04A53C' : '1px solid #FFF',
+                borderRadius: 2,
+                color:  (name.length < 10) ? '#04A53C' : '#FFF',
 
-                }}
-              >
-                SHORT
-              </Typography>
-              <Typography
-                fontSize={12}
-                sx={{
-                  padding: '.5rem',
-                  border: (name.length >= 10 && name.length < 20) ? '1px solid #04A53C' : '1px solid #FFF',
-                  borderRadius: 2,
-                  color:  (name.length >= 10 && name.length < 20) ? '#04A53C' : '#FFF',
-                }}
-              >
-                MEDIUM LENGTH
-              </Typography>
-            </Box> 
-            <Box
-              sx={{
-                display: 'flex',
-                flexDirection: 'row',
-                gap: 1
               }}
             >
+              SHORT
+            </Typography>
+            <Typography
+              fontSize={12}
+              sx={{
+                padding: '.5rem',
+                border: (name.length >= 10 && name.length < 20) ? '1px solid #04A53C' : '1px solid #FFF',
+                borderRadius: 2,
+                color:  (name.length >= 10 && name.length < 20) ? '#04A53C' : '#FFF',
+              }}
+            >
+              MEDIUM LENGTH
+            </Typography>
               <Typography
                 fontSize={12}
                 sx={{
@@ -144,8 +127,7 @@ export default function Iteration({ id, iteration, edit, remove, isLocked, isLas
               >
                 {'VERY VERY VERY LONG (UP TO 35 CHAR)'}
               </Typography>
-            </Box>
-          </Box>
+          </Box> 
 
           <hr 
             style={{


### PR DESCRIPTION
- added fix for pills overlap on small screens
- max length (35chars max) on iteration name
- hide the iteration module name when experiment module is locked 